### PR TITLE
fix: GitHub link typo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -51,7 +51,7 @@
             <p>
                 <a href="https://marc.dev"><i class="fa fa-globe-europe"></i></a>
                 <a href="https://twitter.com/_marcba"><i class="fab fa-twitter"></i></a>
-                <a href="https://github.com.com/themarcba"><i class="fab fa-github"></i></a>
+                <a href="https://github.com/themarcba"><i class="fab fa-github"></i></a>
                 <a href="https://dev.to/_marcba"><i class="fab fa-dev"></i></a>
                 <a href="https://codepen.io/_marcba"><i class="fab fa-codepen"></i></a>
                 <a href="https://www.linkedin.com/in/themarcba/"><i class="fab fa-linkedin"></i></a>


### PR DESCRIPTION
Hi Marc,

I noticed a really small typo in the footer's GitHub url (GitHub.com.com instead of GitHub.com).

Congrats for the cool game!